### PR TITLE
integrar chat widget y limpiar deprecaciones Sass con compatibilidad …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source "https://rubygems.org"
 gemspec
+
+# Improves file watching performance on Windows for jekyll serve --watch.
+group :development do
+	gem "wdm", ">= 0.1.0", platforms: [:mingw, :x64_mingw, :mswin]
+end

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,12 @@
 ## Aranda Docs Jekyll Theme Settings
 
+## Chat Widget
+## ===========
+chat_widget:
+  enabled: true
+  api_base_url: https://app-aranda-docsagentdev.azurewebsites.net
+  version: 2
+
 ## Theme Settings
 ## ==============
 

--- a/_includes/chat-widget.html
+++ b/_includes/chat-widget.html
@@ -1,0 +1,85 @@
+{% if site.chat_widget.enabled %}
+{% assign chat_api_url = site.chat_widget.api_base_url | default: "" %}
+{% assign chat_version = site.chat_widget.version | default: "1" %}
+{% assign chat_lang = site.language | default: "es" %}
+{% if chat_lang == "en" %}
+  {% assign chat_launcher_label = "Intelligent search" %}
+  {% assign chat_locale = "en-US" %}
+{% elsif chat_lang == "pt" %}
+  {% assign chat_launcher_label = "Busca inteligente" %}
+  {% assign chat_locale = "pt-BR" %}
+{% else %}
+  {% assign chat_launcher_label = "Búsqueda inteligente" %}
+  {% assign chat_locale = "es-419" %}
+{% endif %}
+
+<script src="{{ chat_api_url }}/assets/chat-widget-loader.js?v={{ chat_version }}"></script>
+<script>
+  (function () {
+    if (window._arandaChatListenerSet) return;
+    window._arandaChatListenerSet = true;
+
+    function initChatWidget() {
+      if (!window.ArandaChatWidget) return;
+
+      var isSmall = window.innerWidth <= 768;
+
+      window.ArandaChatWidget.init({
+        apiBaseUrl: "{{ chat_api_url }}",
+
+        placement: {
+          corner: "bottom-right",
+          offsetX: isSmall ? 8 : 24,
+          offsetY: isSmall ? 8 : 24,
+        },
+
+        panel: {
+          width:        Math.min(440, window.innerWidth  - (isSmall ? 0 : 32)),
+          height:       Math.min(680, window.innerHeight - (isSmall ? 0 : 32)),
+          borderRadius: 24,
+          borderColor:  "#e4e7ec",
+          background:   "#ffffff",
+        },
+
+        launcher: {
+          label:           "{{ chat_launcher_label }}",
+          iconUrl:         "{{ site.baseurl }}/assets/images/ic_boton_ia.svg",
+          size:            60,
+          backgroundColor: "transparent",
+          textColor:       "#ffffff",
+        },
+
+        embedConfig: {
+          locale: "{{ chat_locale }}",
+          skipIntake: true,
+          branding: {
+            agentName: "Asistente",
+          },
+          shell: {
+            showMaximize: false,
+            themeVars: {
+              "--primary":      "#111827",
+              "--primary-dark": "#0f172a",
+            },
+          },
+          chatkit: {
+            header:  { enabled: false },
+            history: { enabled: true, showDelete: true, showRename: true },
+          },
+        },
+      });
+    }
+
+    document.addEventListener('turbolinks:before-visit', function () {
+      if (window.ArandaChatWidget) {
+        window.ArandaChatWidget.destroy();
+      }
+    });
+
+    document.addEventListener('turbolinks:load', initChatWidget);
+    if (typeof window.Turbolinks === 'undefined') {
+      document.addEventListener('DOMContentLoaded', initChatWidget);
+    }
+  })();
+</script>
+{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="connect-src *.withgoogle.com/ *.azurewebsites.net 'self'; font-src 'self' data: *.azurewebsites.net; img-src https://*.gstatic.com/ http://*.google.com/ *.googleapis.com/ 'self' data: blob: *.azurewebsites.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.googleapis.com *.googletagmanager.com *.azurewebsites.net; style-src *.google.com/ 'self' 'unsafe-inline' *.azurewebsites.net; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.googleapis.com *.googleadservices.com *.googletagmanager.com *.azurewebsites.net; frame-src 'self' *.azurewebsites.net" />
 <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.sg_description }}{% endif %}">
 <meta name="keywords" content="{{ site.keywords }}">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -127,3 +127,4 @@
         }
     });
 </script>
+{% include chat-widget.html %}

--- a/_sass/base/_links.scss
+++ b/_sass/base/_links.scss
@@ -1,10 +1,12 @@
+@use "sass:color";
+
 // Links
 a {
   color: $link-color;   // @CHANGE
   
   &:hover,
   &:focus {
-    color: darken($link-color, 12%);
+    color: color.adjust($link-color, $lightness: -12%);
   }
 }
 

--- a/_sass/components/_sidebar.scss
+++ b/_sass/components/_sidebar.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .sg_sidebar {
     color: $white;
     background: $sidebar-color;
@@ -40,7 +42,7 @@
     }
 
     li {
-        border-top: 1px solid transparentize($white, 0.8);
+        border-top: 1px solid color.adjust($white, $alpha: -0.8);
         line-height: $heading-line-height;
     }
 
@@ -79,7 +81,7 @@
         &:hover,
         &.active {
             color: $white;
-            background-color: transparentize($white, 0.5);
+            background-color: color.adjust($white, $alpha: -0.5);
             margin-left: 1rem;
         }
     }

--- a/_sass/layouts/_roadmap.scss
+++ b/_sass/layouts/_roadmap.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Roadmap Layout
 #sg_roadmap {
   
@@ -77,7 +79,7 @@
     }
 
     &:hover {
-      background: transparentize($smoke, .8);
+      background: color.adjust($smoke, $alpha: -0.8);
 
       .header,
       .icon {

--- a/assets/images/ic_boton_ia.svg
+++ b/assets/images/ic_boton_ia.svg
@@ -1,0 +1,29 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_111_141)">
+<path d="M30 60C46.5685 60 60 46.5685 60 30C60 13.4315 46.5685 0 30 0C13.4315 0 0 13.4315 0 30C0 46.5685 13.4315 60 30 60Z" fill="url(#paint0_linear_111_141)"/>
+<g filter="url(#filter0_d_111_141)">
+<path d="M28.7323 13C28.7323 22.9 22.8394 29.5 14 29.5C22.8394 29.5 28.7323 36.1 28.7323 46C28.7323 36.1 34.6252 29.5 43.4645 29.5C34.6252 29.5 28.7323 22.9 28.7323 13Z" fill="white"/>
+<path d="M41.6962 14.98C41.6962 18.28 39.339 20.26 36.3926 20.26C39.339 20.26 41.6962 22.24 41.6962 25.54C41.6962 22.24 44.0534 20.26 46.9998 20.26C44.0534 20.26 41.6962 18.28 41.6962 14.98Z" fill="white"/>
+<path d="M18.8384 37.0357C18.8384 39.6954 16.4636 41.4685 14.0889 41.4685C16.4636 41.4685 18.8384 43.2417 18.8384 45.9014C18.8384 43.2417 21.2131 41.4685 23.5879 41.4685C21.2131 41.4685 18.8384 39.6954 18.8384 37.0357Z" fill="white"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_111_141" x="10" y="13" width="40.9998" height="41" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_111_141"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_111_141" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_111_141" x1="-0.0051005" y1="29.999" x2="60.004" y2="29.999" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ED0FD3"/>
+<stop offset="0.96" stop-color="#665CF6"/>
+</linearGradient>
+<clipPath id="clip0_111_141">
+<rect width="60" height="60" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
- Se agregó configuración del chat widget en _config.yml:3 con enabled, api_base_url y version.
- Se añadió CSP para habilitar recursos del widget en header.html:2.
- Se incluyó el widget desde scripts.html:130.
- Se agregó el include nuevo chat-widget.html.
- Se agregó el asset ic_boton_ia.svg.
- Se actualizó Gemfile:4 para usar wdm solo en development para Windows.
- Se eliminaron deprecations de Sass migrando a color.adjust en _links.scss:1.
- Se eliminaron deprecations de Sass migrando a color.adjust en _sidebar.scss:1.
- Se eliminaron deprecations de Sass migrando a color.adjust en _roadmap.scss:1.
- Se validó compilación con bundle exec jekyll build sin errores.